### PR TITLE
extending license domain to Thing

### DIFF
--- a/schema/license/README.md
+++ b/schema/license/README.md
@@ -1,0 +1,5 @@
+# schema:sdLicense
+
+This extension allows the `schema:sdLicense` to be applied on all `schema:Thing` instances.
+
+In schema.org, the license application was so far limited to `schema:CreativeWork`, which is not sufficient for applying licenses to an entire knowledge graph. Therefore we extended the domain of `schema:sdLicense` to `schema:Thing`.

--- a/schema/license/sdLicense.json
+++ b/schema/license/sdLicense.json
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "schema": "https://schema.org/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
+  },
+  "@graph": [
+    {
+      "@id": "schema:sdLicense",
+      "schema:domainIncludes": {
+        "@id": "schema:Thing"
+      },
+      "schema:rangeIncludes": [
+        {
+          "@id": "schema:CreativeWork"
+        },
+        {
+          "@id": "schema:URL"
+        }
+      ],
+      "rdfs:label": {
+        "@value": "sdLicense",
+        "@language": "en"
+      },
+      "rdfs:comment": {
+        "@value": "This term is proposed for full integration into Schema.org, pending implementation feedback and adoption from applications and websites.",
+        "@language": "en"
+      },
+      "@type": "rdf:Property"
+    }
+  ]
+}


### PR DESCRIPTION
extend domain of `schema:sdLicense` to `schema:Thing`